### PR TITLE
To accept kotlin & gradle versions from root project for React-native upgrade

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,7 @@
 
 buildscript {
-    ext.kotlin_version = '1.4.31'
+    def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['RNHV_kotlinVersion']
+    def gradle_version = rootProject.ext.has('gradleVersion') ? rootProject.ext.get('gradleVersion') : project.properties['RNHV_gradleVersion']
 
     repositories {
         google()
@@ -8,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.4'
+        classpath "com.android.tools.build:gradle:$gradle_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-android-extensions:$kotlin_version"
     }
@@ -46,6 +47,8 @@ repositories {
         url "$rootDir/../../../node_modules/react-native/android"
     }
 }
+
+def kotlin_version = safeExtGet('kotlinVersion', project.properties['RNHV_kotlinVersion'])
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,20 @@
+# Project-wide Gradle settings.
+
+# IDE (e.g. Android Studio) users:
+# Gradle settings configured through the IDE *will override*
+# any settings specified in this file.
+
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx10248m -XX:MaxPermSize=256m
+#org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+RNHV_kotlinVersion=1.6.20
+RNHV_gradleVersion=3.4.4


### PR DESCRIPTION
In this PR , I've added two vars in `gradle.properties` 
- RNHV_kotlinVersion
- RNHV_gradleVersion 
which will serve as fallback values if the root project consuming this library doesnt have the following variables set in their `build.gradle`
- `kotlinVersion`
- `gradleVersion`

this helps us pass values to the library when we upgrade our gradle version for status-mobile :) 
This is needed for : https://github.com/status-im/status-mobile/issues/14386
Reference : https://github.com/status-im/status-mobile/issues/14386#issuecomment-1445357642